### PR TITLE
Add a coreml conversion script 

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ The estimated calorie estimates are roughly in the range produced by wearable de
 From our experiments, our estimates correlate well with the workout intensity (intense workouts burn more calories) so, regardless of the absolute accuracy, it should be fair to use this metric to compare one workout to another.
 
 
+## Running on an iOS Device and CoreML Conversion
+
+If you're interested in mobile app development and want to run our models on iOS devices, please check out [20bn-realtimenet-ios](https://github.com/TwentyBN/20bn-realtimenet-iOS).
+This other repo provides step by step instructions on how to get our gesture demo to run on an iOS device.
+One of the steps involves converting our Pytorch models to the CoreML format, which can be done from this repo using the following script:
+
+```shell
+python scripts/conversion/convert_to_coreml.py --backbone=efficientnet --classifier=efficient_net_gesture_control --output_name=realtimenet
+```
+
 ## Citation
 
 We now have a [blogpost](https://medium.com/twentybn/towards-situated-visual-ai-via-end-to-end-learning-on-video-clips-2832bd9d519f) you can cite:

--- a/README.md
+++ b/README.md
@@ -121,8 +121,7 @@ From our experiments, our estimates correlate well with the workout intensity (i
 
 ## Running on an iOS Device and CoreML Conversion
 
-If you're interested in mobile app development and want to run our models on iOS devices, please check out [20bn-realtimenet-ios](https://github.com/TwentyBN/20bn-realtimenet-iOS).
-This other repo provides step by step instructions on how to get our gesture demo to run on an iOS device.
+If you're interested in mobile app development and want to run our models on iOS devices, please check out [20bn-realtimenet-ios](https://github.com/TwentyBN/20bn-realtimenet-iOS) for step by step instructions on how to get our gesture demo to run on an iOS device.
 One of the steps involves converting our Pytorch models to the CoreML format, which can be done from this repo using the following script:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cd 20bn-realtimenet
 
 ### 2. Install Dependencies
 
-Create a new virtual environment. The following instruction uses [conda](https://docs.conda.io/en/latest/miniconda.html).
+Create a new virtual environment. The following instruction uses [conda](https://docs.conda.io/en/latest/miniconda.html) (recommended).
 You can also create a new virtual environment with `virtualenv`.
 
 ```shell

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ docopt                  ==0.6.2       # MIT
 # Dependencies needed for converting Pytorch models to CoreML
 tensorflow              ==1.14.0
 keras                   ==2.2.4
-coremltool              ==3.3
+coremltools             ==3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,8 @@ numpy                   ==1.16.2      # BSD
 opencv-python           ==3.4.3.18    # MIT
 queuelib                ==1.5.0       # BSD
 docopt                  ==0.6.2       # MIT
+
+# Dependencies need for converting Pytorch models to CoreML
+tensorflow              ==1.14.0
+keras                   ==2.2.4
+coremltool              ==3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ opencv-python           ==3.4.3.18    # MIT
 queuelib                ==1.5.0       # BSD
 docopt                  ==0.6.2       # MIT
 
-# Dependencies need for converting Pytorch models to CoreML
+# Dependencies needed for converting Pytorch models to CoreML
 tensorflow              ==1.14.0
 keras                   ==2.2.4
 coremltool              ==3.3

--- a/scripts/conversion/cfg/efficientnet.cfg
+++ b/scripts/conversion/cfg/efficientnet.cfg
@@ -414,12 +414,3 @@ activation=relu6
 
 [globalaveragepooling2d]
 layer_name=poolit
-
-[Linear]
-module_name=0
-layer_name=classifier
-outputs=30
-
-[output]
-layer_name=globalclassifier
-

--- a/scripts/conversion/cfg/efficientnet.cfg
+++ b/scripts/conversion/cfg/efficientnet.cfg
@@ -1,0 +1,425 @@
+[input]
+layer_name=new_frame
+image=True
+size=224,160,3
+
+[input]
+layer_name=frame_back_1
+image=True
+size=224,160,3
+
+[input]
+layer_name=frame_back_2
+image=True
+size=224,160,3
+
+[input]
+layer_name=frame_back_3
+image=True
+size=224,160,3
+
+# start with 4 frames
+# starting 2D conv
+[convolutional]
+module_name=cnn.0.0
+#batch_normalize=1
+filters=32
+size=3
+stride=2
+pad=1
+activation=relu6
+
+## ******** start a new block ******
+# 1_24_1_1_3
+[InvResidual]
+module_name=cnn.1
+layer_name=residual_0
+xratio=1
+out_channels=24
+stride=1
+size=3
+tstride=1
+activation=relu6
+
+#[output]
+#layer_name=shift_test_output0
+
+# ******** start a new block ******
+# t, c, n, s, k
+# 6_32_4_2_3   1 of 4
+[InvResidual]
+module_name=cnn.2
+layer_name=residual_1
+xratio=6
+out_channels=32
+stride=2
+size=3
+tstride=1
+activation=relu6
+
+#[output]
+#layer_name=shift_test_output1
+
+# 6_32_4_2_3   2 of 4
+# **** First Shift (3D)
+[InvResidual]
+module_name=cnn.3
+layer_name=residual_2
+xratio=6
+out_channels=32
+stride=1
+size=3
+shift=1
+tstride=1
+activation=relu6
+
+#[output]
+#layer_name=shift_test_output2
+
+# 6_32_4_2_3   3 of 4
+[InvResidual]
+module_name=cnn.4
+layer_name=residual_3
+xratio=6
+out_channels=32
+stride=1
+size=3
+tstride=1
+activation=relu6
+
+#[output]
+#layer_name=next_test_output3
+
+
+# 6_32_4_2_3   4 of 4
+[InvResidual]
+module_name=cnn.5
+layer_name=residual_4
+xratio=6
+out_channels=32
+stride=1
+size=3
+tstride=1
+activation=relu6
+
+#[output]
+#layer_name=next_test_output4
+
+# [6, 56, 4, 2, 5], 1 0f 4
+# 1 of 4
+[InvResidual]
+module_name=cnn.6
+layer_name=residual_5
+xratio=6
+out_channels=56
+stride=2
+size=5
+tstride=1
+activation=relu6
+
+#[output]
+#layer_name=next_test_output5
+
+# 2 of 4
+# **** Second Shift (3D)
+# **** Temporal Stride
+[InvResidual]
+module_name=cnn.7
+layer_name=residual_6
+xratio=6
+out_channels=56
+stride=1
+size=5
+shift=1
+tstride=2
+activation=relu6
+
+#[output]
+#layer_name=stride_test_output
+
+# 3 of 4
+[InvResidual]
+module_name=cnn.8
+layer_name=residual_7
+xratio=6
+out_channels=56
+stride=1
+size=5
+tstride=1
+activation=relu6
+
+#[output]
+#layer_name=next_test_output7
+
+# 4 of 4
+[InvResidual]
+module_name=cnn.9
+layer_name=residual_8
+xratio=6
+out_channels=56
+stride=1
+size=5
+tstride=1
+activation=relu6
+
+# [6, 112, 6, 2, 3],
+# 1 of 6
+[InvResidual]
+module_name=cnn.10
+layer_name=residual_9
+xratio=6
+out_channels=112
+stride=2
+size=3
+tstride=1
+activation=relu6
+
+# 2 of 6
+[InvResidual]
+module_name=cnn.11
+layer_name=residual_10
+xratio=6
+out_channels=112
+stride=1
+size=3
+shift=1
+tstride=1
+activation=relu6
+
+# 3 of 6
+[InvResidual]
+module_name=cnn.12
+layer_name=residual_11
+xratio=6
+out_channels=112
+stride=1
+size=3
+tstride=1
+activation=relu6
+
+# 4 of 6
+[InvResidual]
+module_name=cnn.13
+layer_name=residual_12
+xratio=6
+out_channels=112
+stride=1
+size=3
+tstride=1
+activation=relu6
+
+# 5 of 6
+[InvResidual]
+module_name=cnn.14
+layer_name=residual_13
+xratio=6
+out_channels=112
+stride=1
+size=3
+shift=1
+tstride=2
+activation=relu6
+
+# 6 of 6
+[InvResidual]
+module_name=cnn.15
+layer_name=residual_14
+xratio=6
+out_channels=112
+stride=1
+size=3
+tstride=1
+activation=relu6
+
+# [6, 160, 6, 1, 5]
+# 1 of 6
+[InvResidual]
+module_name=cnn.16
+layer_name=residual_15
+xratio=6
+out_channels=160
+stride=1
+size=5
+tstride=1
+activation=relu6
+
+# 2 of 6
+[InvResidual]
+module_name=cnn.17
+layer_name=residual_16
+xratio=6
+out_channels=160
+stride=1
+size=5
+shift=1
+tstride=1
+activation=relu6
+
+# 3 of 6
+[InvResidual]
+module_name=cnn.18
+layer_name=residual_17
+xratio=6
+out_channels=160
+stride=1
+size=5
+tstride=1
+activation=relu6
+
+# 4 of 6
+[InvResidual]
+module_name=cnn.19
+layer_name=residual_18
+xratio=6
+out_channels=160
+stride=1
+size=5
+tstride=1
+activation=relu6
+
+# 5 of 6
+[InvResidual]
+module_name=cnn.20
+layer_name=residual_19
+xratio=6
+out_channels=160
+stride=1
+size=5
+shift=1
+tstride=1
+activation=relu6
+
+# 6 of 6
+[InvResidual]
+module_name=cnn.21
+layer_name=residual_20
+xratio=6
+out_channels=160
+stride=1
+size=5
+tstride=1
+activation=relu6
+
+# [6, 272, 8, 2, 5]
+# 1 of 8
+[InvResidual]
+module_name=cnn.22
+layer_name=residual_21
+xratio=6
+out_channels=272
+stride=2
+size=5
+tstride=1
+activation=relu6
+
+# 2 of 8
+[InvResidual]
+module_name=cnn.23
+layer_name=residual_22
+xratio=6
+out_channels=272
+stride=1
+size=5
+shift=1
+tstride=1
+activation=relu6
+
+# 3 of 8
+[InvResidual]
+module_name=cnn.24
+layer_name=residual_23
+xratio=6
+out_channels=272
+stride=1
+size=5
+tstride=1
+activation=relu6
+
+# 4 of 8
+[InvResidual]
+module_name=cnn.25
+layer_name=residual_24
+xratio=6
+out_channels=272
+stride=1
+size=5
+shift=1
+tstride=1
+activation=relu6
+
+# 5 of 8
+[InvResidual]
+module_name=cnn.26
+layer_name=residual_25
+xratio=6
+out_channels=272
+stride=1
+size=5
+tstride=1
+activation=relu6
+
+# 6 of 8
+[InvResidual]
+module_name=cnn.27
+layer_name=residual_26
+xratio=6
+out_channels=272
+stride=1
+size=5
+tstride=1
+activation=relu6
+
+# 7 of 8
+[InvResidual]
+module_name=cnn.28
+layer_name=residual_27
+xratio=6
+out_channels=272
+stride=1
+size=5
+tstride=1
+activation=relu6
+
+# 8 of 8
+[InvResidual]
+module_name=cnn.29
+layer_name=residual_28
+xratio=6
+out_channels=272
+stride=1
+size=5
+tstride=1
+activation=relu6
+
+# [6, 448, 1, 1, 3]
+# 1 of 1
+[InvResidual]
+module_name=cnn.30
+layer_name=residual_29
+xratio=6
+out_channels=448
+stride=1
+size=3
+tstride=1
+activation=relu6
+
+[convolutional]
+module_name=cnn.31.0
+#batch_normalize=1
+filters=1280
+size=1
+stride=1
+pad=1
+activation=relu6
+
+[globalaveragepooling2d]
+layer_name=poolit
+
+[Linear]
+module_name=0
+layer_name=classifier
+outputs=30
+
+[output]
+layer_name=globalclassifier
+

--- a/scripts/conversion/cfg/logistic_regression.cfg
+++ b/scripts/conversion/cfg/logistic_regression.cfg
@@ -1,0 +1,7 @@
+[Linear]
+module_name=0
+layer_name=classifier
+outputs=NUM_CLASSES
+
+[output]
+layer_name=globalclassifier

--- a/scripts/conversion/convert_to_coreml.py
+++ b/scripts/conversion/convert_to_coreml.py
@@ -30,7 +30,7 @@ try:
     from coremltools.models.neural_network import datatypes, NeuralNetworkBuilder
 except:
     raise Exception("This CoreML conversion script requires additional dependencies. \n"
-                    "Run: pip install tensorflow==1.14.0 keras==2.2.4 coremltools==3.3 ")
+                    "Run: pip install tensorflow==1.14.0 keras==2.2.4 coremltools==3.3")
 
 
 parser = argparse.ArgumentParser(description='Marknet To Keras/CoreML Converter.')
@@ -119,8 +119,8 @@ def _main(args):
         print(a, getattr(args, a))
     model_dir = 'resources'
     config_file = 'scripts/conversion/cfg/efficientnet.cfg'
-    keras_file = os.path.join(model_dir, 'efficientnet_keras.h5')
     model_name = 'strided_inflated_efficientnet'
+    keras_file = os.path.join(model_dir, model_name + '.h5')
 
     if args.generate_coreml:
         if args.float16:

--- a/scripts/conversion/convert_to_coreml.py
+++ b/scripts/conversion/convert_to_coreml.py
@@ -67,7 +67,6 @@ SUPPORTED_BACKBONE_CONVERSIONS = {
         {
             'config_file': 'scripts/conversion/cfg/efficientnet.cfg',
             'weights_file': 'resources/strided_inflated_efficientnet.ckpt',
-            'model_name': 'strided_inflated_efficientnet',
             'conversion_parameters': {**DEFAULT_CONVERSION_PARAMETERS, 'image_scale': 255.}
         }
 }
@@ -118,9 +117,8 @@ def convert(backbone_settings, classifier_settings, output_name, float16, plot_m
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
-    model_name = backbone_settings['model_name']
     conversion_parameters = backbone_settings['conversion_parameters']
-    keras_file = os.path.join(output_dir, model_name + '.h5')
+    keras_file = os.path.join(output_dir, output_name + '.h5')
 
     if float16:
         coreml_file = os.path.join(output_dir, output_name + '.FP16-32.mlmodel')

--- a/scripts/conversion/convert_to_coreml.py
+++ b/scripts/conversion/convert_to_coreml.py
@@ -1,0 +1,1148 @@
+#! /usr/bin/env python
+"""
+Reads Darknet config and weights and creates Keras model with TF backend.
+
+"""
+
+import argparse
+import configparser
+import io
+import os
+import copy
+from collections import defaultdict
+
+import torch
+import numpy as np
+
+try:
+    from keras import backend as K
+    from keras.layers import (Conv1D, Conv2D, Input, ZeroPadding2D, Add, SeparableConv1D, SeparableConv2D, Permute, Dense,GlobalAveragePooling2D,
+                              UpSampling2D, MaxPooling2D, Concatenate, Cropping1D, Cropping2D, concatenate, Activation, DepthwiseConv2D, Softmax)
+    from keras.layers.advanced_activations import (LeakyReLU, ReLU, PReLU)
+    from keras.layers.normalization import BatchNormalization
+    from keras.initializers import RandomNormal
+    from keras.models import Model
+    from keras.regularizers import l2
+    from keras.utils.vis_utils import plot_model as plot
+    from tensorflow import slice
+    import tensorflow as tf
+    import coremltools
+    from coremltools.models.neural_network import datatypes, NeuralNetworkBuilder
+except:
+    raise Exception("This CoreML conversion script requires additional dependencies. \n"
+                    "Run: pip install tensorflow==1.14.0 keras==2.2.4 coremltools==3.3 ")
+
+
+parser = argparse.ArgumentParser(description='Marknet To Keras/CoreML Converter.')
+# parser.add_argument('model_dir', help='Path to model files.')
+# parser.add_argument('config_file', help='Name of cfg file.')
+# parser.add_argument('checkpoint_file', help='Pytorch checkpoint filename.')
+# parser.add_argument('model_name', help='Model name for output files.')
+parser.add_argument(
+    '-p',
+    '--plot_model',
+    help='Plot generated Keras model and save as image.',
+    action='store_true')
+parser.add_argument(
+    '-c',
+    '--generate_coreml',
+    help='Generate a CoreML model directly.',
+    action='store_true')
+parser.add_argument(
+    '--red_bias',
+    type=float,
+    help='red bias, float value; model gets (input-(bias*255)) * scale/255')
+parser.add_argument(
+    '--green_bias',
+    type=float,
+    help='green bias, float value; model gets (input-(bias*255)) * scale/255')
+parser.add_argument(
+    '--blue_bias',
+    type=float,
+    help='blue bias, float value; model gets (input-(bias*255)) * scale/255')
+parser.add_argument(
+    '--image_scale',
+    type=float,
+    help='image_scale, float value; model gets (input-(bias*255)) * scale/255')
+parser.add_argument(
+    '--red_scale',
+    type=float,
+    help='red scale, float value; model gets (input-(bias*255)) * scale/255')
+parser.add_argument(
+    '--green_scale',
+    type=float,
+    help='green scale, float value; model gets (input-(bias*255)) * scale/255')
+parser.add_argument(
+    '--blue_scale',
+    type=float,
+    help='blue scale, float value; model gets (input-(bias*255)) * scale/255')
+parser.add_argument(
+    '-fp16',
+    '--float16',
+    help='quantize to 16-bit floating point',
+    action='store_true')
+parser.add_argument(
+    '-n',
+    '--normalize_inputs',
+    help='Add input scaling layers for normalizing image inputs.',
+    action='store_true')
+parser.add_argument(
+    '-pr',
+    '--use_prelu',
+    help='Use PreLU configured to be like LeakyReLU (for TFLite/Android).',
+    action='store_true')
+
+
+
+def unique_config_sections(config_file):
+    """Convert all config sections to have unique names.
+
+    Adds unique suffixes to config sections for compatibility with configparser.
+    """
+    section_counters = defaultdict(int)
+    output_stream = io.StringIO()
+    with open(config_file) as fin:
+        for line in fin:
+            if line.startswith('['):
+                section = line.strip().strip('[]')
+                _section = section + '_' + str(section_counters[section])
+                section_counters[section] += 1
+                line = line.replace(section, _section)
+            output_stream.write(line)
+    output_stream.seek(0)
+    return output_stream
+
+# %%
+def _main(args):
+    print('arguments:')
+    for a in vars(args):
+        print(a, getattr(args, a))
+    model_dir = 'resources'
+    config_file = 'scripts/conversion/cfg/efficientnet.cfg'
+    keras_file = os.path.join(model_dir, 'efficientnet_keras.h5')
+    model_name = 'strided_inflated_efficientnet'
+
+    if args.generate_coreml:
+        if args.float16:
+            coreml_file = os.path.join(model_dir, model_name + '.FP16-32.mlmodel')
+            normalized_file = os.path.join(model_dir, model_name + '.norm.FP16-32.mlmodel')
+        else:
+            coreml_file = os.path.join(model_dir, model_name + '-32.mlmodel')
+            normalized_file = os.path.join(model_dir, model_name + '.norm-32.mlmodel')
+
+    if args.plot_model:
+        plot_file = os.path.join(model_dir, model_name +'.png')
+
+    # Load weights and config.
+    print('Loading weights.')
+
+    # ptweights_file = open(weights_file, 'rb')
+
+    weights_backbone = torch.load('resources/strided_inflated_efficientnet.ckpt',
+                                  map_location='cpu')
+    weights_classifier = torch.load('resources/gesture_detection/efficientnet_logistic_regression.ckpt',
+                                    map_location='cpu')
+    ptweights = {**weights_backbone, **weights_classifier}
+
+
+    for key in ptweights.keys():
+        print(key, ptweights[key].shape)
+
+    print('Parsing Darknet config.')
+    unique_config_file = unique_config_sections(config_file)
+    cfg_parser = configparser.ConfigParser()
+    cfg_parser.read_file(unique_config_file)
+    weight_decay = 5e-4
+
+    def invResidual(module_name, layer_name, frames, out_channels, xratio, size, stride, shift, tstride, fake_weights):
+
+        s=0
+        if shift:
+            print('3D conv block')
+            tsize = 3
+        else:
+            print('2D conv block')
+            tsize = 1
+        prev_layer_shape = K.int_shape(all_layers[-1])
+        input_channels = prev_layer_shape[-1]
+        x_channels = input_channels * xratio
+        image_size = prev_layer_shape[-3], prev_layer_shape[-2]
+        print('input image size: ', image_size)
+        num_convs = int(frames / tstride)
+        inputs_needed = (tstride * (num_convs - 1)) + tsize
+        #            inputs_needed = frames + tsize - 1
+        if inputs_needed > 1:
+            print('inputs_needed: ', inputs_needed)
+        old_frames_to_read = inputs_needed - frames
+        new_frames_to_save = min(frames, old_frames_to_read)
+        print('num_convs: ', num_convs,
+              'inputs_needed: ', inputs_needed,
+              'history frames needed: ', old_frames_to_read,
+              'frames to save: ', new_frames_to_save,
+              'tstride: ', tstride)
+        # create (optional) expansion pointwise convolution layer
+
+        input_indexes=[]
+        for i in range(num_convs):
+            input_indexes.append(len(all_layers) - frames + (i * tstride))
+
+        if xratio != 1:
+            print('---------- Insert channel multiplier pointwise conv -------------')
+            # attach output ports to inputs we will need next pass if tsize>1
+            for f in range(new_frames_to_save):
+                out_index.append(len(all_layers) - frames + f)
+                out_names.append(module_name + '_save_' + str(f))
+
+            # create input ports for required old frames if tsize>1
+            for f in range(old_frames_to_read):
+                h_name = module_name + '_history_' + str(f)
+                all_layers.append(Input(shape=(image_size[0], image_size[1], input_channels), name=h_name))
+                in_names.append(h_name)
+                in_index.append(len(all_layers) - 1)
+
+
+            # get weights
+            n = module_name + '.conv.' + str(s) + '.0.'
+            if n + 'weight' in ptweights:
+                weights_pt = ptweights[n + 'weight']
+                print('checkpoint: ', weights_pt.shape,)
+                weights_k = np.transpose(weights_pt, [2, 3, 1, 0])
+                bias = ptweights[n + 'bias']
+            else:
+                print('missing weight ', n + 'weight')
+                weights_k = np.random.rand(1, 1,  tsize * input_channels, x_channels)
+                bias = np.zeros(x_channels)
+                fake_weights = True
+
+
+            expected_weights_shape = (1, 1,  tsize * input_channels, x_channels)
+            print('weight shape, expected : ', expected_weights_shape,
+                  'transposed: ', weights_k.shape)
+
+            if (weights_k.shape != expected_weights_shape):
+                print('weight matrix shape is wrong, making a fake one')
+                weights_k = np.random.rand(1, 1,  tsize * input_channels, x_channels)
+                bias = np.zeros(x_channels)
+                fake_weights = True
+
+            weights = [weights_k, bias]
+
+            inputs = []
+            outputs = []
+
+            for f in range(inputs_needed):
+#                print('input index: ', len(all_layers) - inputs_needed + f, ' shape: ',
+#                      all_layers[len(all_layers) - inputs_needed + f].shape)
+                inputs.append(all_layers[len(all_layers) - inputs_needed + f])
+                if merge_in > 0:
+#                    print('merge input index: ', len(all_layers) - inputs_needed + f, ' shape: ',
+#                          all_layers[len(all_layers) - (2 * inputs_needed) + f].shape)
+                    inputs.append(all_layers[len(all_layers) - (2 * inputs_needed) + f])
+
+            for f in range(int(frames / tstride)):
+                layers = []
+                if tsize > 1:
+                    #                    print('concatenate layers:')
+                    for t in range(tsize):
+                        # offset is constant with f, except if tstride,
+                        # then steps by extra step every time through
+#                        layers.append(inputs[t + (f * (tstride))])
+                        layers.append(inputs[(tsize-t-1) + (f * (tstride))])
+                    cat_layer = Concatenate()(layers)
+                else:
+                    cat_layer = inputs[f * (tstride)]
+
+                outputs.append((Conv2D(
+                    x_channels, (1,1),
+                    use_bias=not batch_normalize,
+                    weights=weights,
+                    activation=None,
+                    padding='same'))(cat_layer))
+
+            print('parallel convs: ', int(frames / tstride), ' : ', K.int_shape(cat_layer))
+
+            if activation == 'leaky':
+                for f in range(int(frames / tstride)):
+                    if not args.use_prelu:
+                        outputs[f] = LeakyReLU(alpha=0.1)(outputs[f])
+                    else:
+                        outputs[f] = PReLU(alpha_initializer=RandomNormal(mean=0.1, stddev=0.0, seed=None),
+                                   shared_axes=[1, 2])(outputs[f])
+            elif activation == 'relu6':
+                for f in range(int(frames / tstride)):
+                    outputs[f] = ReLU(max_value=6)(outputs[f])
+
+            for f in range(int(frames / tstride)):
+                all_layers.append(outputs[f])
+            s +=1
+            frames = int(frames / tstride)
+
+        else:
+            print('Skipping channel multiplier pointwise conv, no expansion')
+
+        # create groupwise convolution
+        # get weights
+        print('---------- Depthwise conv -------------')
+        n = module_name + '.conv.' + str(s) + '.0.'
+        print('module name base: ', n)
+        if n + 'weight' in ptweights:
+            weights_pt = ptweights[n + 'weight']
+            print('checkpoint: ', weights_pt.shape,)
+            weights_k = np.transpose(weights_pt, [2, 3, 0, 1])
+            bias = ptweights[n + 'bias']
+        else:
+            print('missing weight ', n + 'weight')
+            weights_k = np.random.rand(size, size,  x_channels, 1)
+            bias = np.zeros(x_channels)
+            fake_weights = True
+
+        expected_weights_shape = (size, size,  x_channels, 1)
+        print('weight shape, expected : ', expected_weights_shape,
+              'transposed: ', weights_k.shape)
+
+        if (weights_k.shape != expected_weights_shape):
+            print('weight matrix shape is wrong, making a fake one')
+            fake_weights = True
+            weights_k = np.random.rand(size, size, x_channels, 1)
+            bias = np.zeros(x_channels)
+
+        weights = [weights_k, bias]
+
+        inputs = []
+        outputs = []
+
+        padding = 'same' if pad == 1 and stride == 1 else 'valid'
+
+        for f in range(frames):
+#            print('input index: ', len(all_layers) - frames + f, ' shape: ',
+#                  all_layers[len(all_layers) - frames + f].shape)
+            inputs.append(all_layers[len(all_layers) - frames + f])
+
+        if stride > 1:
+            for f in range(len(inputs)):
+                if size == 3:   # originally for all sizes
+                    inputs[f] = ZeroPadding2D(((size - stride, 0), (size - stride, 0)))(inputs[f])
+                elif size == 5: # I found this works...
+                    inputs[f] = ZeroPadding2D(((2,2), (2,2)))(inputs[f])
+                else:
+                    print('I have no idea what to do for size ', size)
+                    exit()
+
+
+        print('parallel convs: ', f, ' : ', K.int_shape(inputs[0]), 'padding: ', padding)
+        for f in range(frames):
+
+            outputs.append((DepthwiseConv2D(
+                (size, size),
+                strides=(stride,stride),
+                use_bias=not batch_normalize,
+                weights=weights,
+                activation=None,
+                padding=padding))(inputs[f]))
+
+        if activation == 'leaky':
+            for f in range(int(frames)):
+                if not args.use_prelu:
+                    outputs[f] = LeakyReLU(alpha=0.1)(outputs[f])
+                else:
+                    outputs[f] = PReLU(alpha_initializer=RandomNormal(mean=0.1, stddev=0.0, seed=None),
+                                       shared_axes=[1, 2])(outputs[f])
+        elif activation == 'relu6':
+            for f in range(int(frames)):
+                outputs[f] = ReLU(max_value=6)(outputs[f])
+
+        for f in range(int(frames)):
+            all_layers.append(outputs[f])
+        s +=1
+
+        # create pointwise convolution
+        # get weights
+        print('---------- Pointwise conv -------------')
+        n = module_name + '.conv.' + str(s) + '.'
+        print('module name base: ', n)
+        if n + 'weight' in ptweights:
+            weights_pt = ptweights[n + 'weight']
+            print('checkpoint: ', weights_pt.shape,)
+            weights_k = np.transpose(weights_pt, [2, 3, 1, 0])
+            bias = ptweights[n + 'bias']
+        else:
+            print('missing weight ', n + 'weight')
+            fake_weights = True
+            weights_k = np.random.rand(1, 1,  x_channels, out_channels)
+            bias = np.zeros(out_channels)
+
+        expected_weights_shape = (1, 1,  x_channels, out_channels)
+        print('weight shape, expected : ', expected_weights_shape,
+              'transposed: ', weights_k.shape)
+
+        if (weights_k.shape != expected_weights_shape):
+            print('weight matrix shape is wrong, making a fake one')
+            fake_weights = True
+            weights_k = np.random.rand(1, 1,  x_channels, out_channels)
+            bias = np.zeros(out_channels)
+
+        weights = [weights_k, bias]
+        print("combined shape: ", weights[0].shape, weights[1].shape)
+
+        inputs = []
+        outputs = []
+
+        for f in range(frames):
+#            print('input index: ', len(all_layers) - frames + f, ' shape: ',
+#                  all_layers[len(all_layers) - frames + f].shape)
+            inputs.append(all_layers[len(all_layers) - frames + f])
+
+        print('parallel convs: ', f, ' : ', K.int_shape(all_layers[len(all_layers) - frames]))
+        for f in range(frames):
+            conv_input = all_layers[len(all_layers) - frames + f]
+
+            outputs.append((Conv2D(
+                out_channels, (1,1),
+                use_bias=not batch_normalize,
+                weights=weights,
+                activation=None,
+                padding='same'))(conv_input))
+
+        if stride == 1 and input_channels == out_channels:
+            for f in range(int(frames)):
+#                if tstride==2:
+#                    out_index.append(input_indexes[f])
+#                    out_names.append('outputx_' + str(f) + layer_name)
+
+                all_layers.append(Add()([all_layers[input_indexes[f]], outputs[f]]))
+        else:
+            for f in range(int(frames)):
+                all_layers.append(outputs[f])
+        s +=1
+
+        return frames, fake_weights
+
+    print('Creating Keras model.')
+    all_layers = []
+    out_index = []
+    out_names = []
+    in_index = []
+    in_names = []
+    image_inputs = []
+    layer_names = dict()
+    frames = 0
+    coreml_list = []
+    fake_weights = False
+    np.random.seed(13)      # start the same way each time...
+
+    for section in cfg_parser.sections():
+        print('    ***** Parsing section {} ************'.format(section))
+        if section.startswith('convolutional'):
+            if frames > 1:
+                print('frames: ', frames)
+            module_name = 'module_name' in cfg_parser[section]
+            if module_name:
+                module_name =  cfg_parser[section]['module_name']
+                print(module_name)
+            else:
+                print('missing required module name for conv module')
+            layer_name = 'layer_name' in cfg_parser[section]
+            if layer_name:
+                layer_name =  cfg_parser[section]['layer_name']
+                print(layer_name)
+            else:
+                layer_name = str(len(all_layers) - 1)
+            tstride = 'tstride' in cfg_parser[section]
+            if tstride:
+                tstride =  int(cfg_parser[section]['tstride'])
+            else:
+                tstride = 1
+            merge_in = 'merge_in' in cfg_parser[section]
+            if merge_in:
+                merge_in = int(cfg_parser[section]['merge_in'])
+            else:
+                merge_in = 0
+            share = 'share' in cfg_parser[section]
+            no_output = 'no_output' in cfg_parser[section]
+            image_input = 'image' in cfg_parser[section]
+            filters = int(cfg_parser[section]['filters'])
+            size = int(cfg_parser[section]['size'])
+            stride = int(cfg_parser[section]['stride'])
+            pad = int(cfg_parser[section]['pad'])
+            activation = cfg_parser[section]['activation']
+            batch_normalize = 'batch_normalize' in cfg_parser[section]
+            tsize  = 'tsize' in cfg_parser[section]
+            if tsize:
+                tsize = int(cfg_parser[section]['tsize'])
+            else:
+                tsize = 1
+            prev_layer_shape = K.int_shape(all_layers[-1])
+            input_channels = prev_layer_shape[-1]
+            image_size = prev_layer_shape[-3],prev_layer_shape[-2]
+#            print('conv input image size: ', image_size)
+
+            num_convs = int(frames/tstride)
+            if num_convs > 1:
+                print('num_convs: ', num_convs)
+            inputs_needed = (tstride * (num_convs-1)) + tsize
+#            inputs_needed = frames + tsize - 1
+            if inputs_needed > 1:
+                print('inputs_needed: ', inputs_needed)
+            old_frames_to_read = inputs_needed - frames
+            if old_frames_to_read < 0:
+                print('negative number of old frames!!!!!!!!!')
+            if old_frames_to_read:
+                print('history frames needed: ', old_frames_to_read)
+            new_frames_to_save = min(frames, old_frames_to_read)
+            if new_frames_to_save:
+                print('new frames to save: ', new_frames_to_save)
+
+            # attach output ports to inputs we will need next pass
+            if no_output is False:
+                for f in range(new_frames_to_save):
+                    out_index.append(len(all_layers) - frames + f)
+                    out_names.append(module_name + '_save_' + str(f))
+
+            # attach output ports to unsaved inputs if we need to share inputs to a slave network
+            if share is True:
+                for f in range(new_frames_to_save, frames):
+                    out_index.append(len(all_layers) - frames + f)
+                    out_names.append(module_name + '_share_' + str(f))
+
+            # create input ports for required old frames
+            for f in range(old_frames_to_read):
+                xx = module_name + '_history_' + str(f)
+                in_names.append(xx)
+                if image_input:
+                    image_inputs.append(xx)
+                all_layers.append(Input(shape=(image_size[0], image_size[1], input_channels),
+                                    name=xx))
+#                print('History input at: ', len(all_layers) - 1)
+                in_index.append(len(all_layers) - 1)
+
+            # create input ports for merged-in frames
+            if merge_in >0:
+                input_channels = input_channels + merge_in
+                for f in range(inputs_needed):
+                    xx = module_name + '_merge_in_' + str(f)
+                    in_names.append(xx)
+                    all_layers.append(Input(shape=(image_size[0], image_size[1], merge_in),
+                                            name=xx))
+                    print('merge_in input at: ', len(all_layers) - 1)
+                    in_index.append(len(all_layers) - 1)
+
+            padding = 'same' if pad == 1 and stride == 1 else 'valid'
+
+            # Setting weights.
+            # Darknet serializes convolutional weights as:
+            # [bias/beta, [gamma, mean, variance], conv_weights]
+
+            # extract parameter for this module from Pytorch checkpoint file
+            conv_weights_pt = np.random.rand(input_channels, filters, tsize, size, size)
+            conv_bias = [0]
+            if module_name + '.weight' in ptweights:
+                conv_weights_pt = ptweights[module_name + '.weight']
+                print("weight: ", module_name + '.weight', ptweights[module_name + '.weight'].shape)
+                # convert to tsize list of 2d conv weight matrices, transposed for Keras
+                w_list = []
+                if len(conv_weights_pt.shape)==5: # check if this is a 3D conv being unfolded
+                    for t in range(tsize):
+                        w_list.append(np.transpose(conv_weights_pt[:,:,tsize-1-t,:,:], [2,3,1,0]))
+                else: # this is simply a single 2D conv
+                     w_list.append(np.transpose(conv_weights_pt[:, :, :, :], [2, 3, 1, 0]))
+                # concatenate along the in_dim axis the tsize matrices
+                conv_weights = np.concatenate(w_list, axis=2)
+                if not batch_normalize:
+                    conv_bias = ptweights[module_name + '.bias']
+            else:
+                print('cannot find weight: ', module_name + '.weight')
+                fake_weights = True
+                conv_weights = np.random.rand(size, size, tsize*input_channels, filters)
+                conv_bias = np.zeros(filters)
+
+            if batch_normalize:
+                bn_bias = ptweights[module_name + '.batchnorm.bias']
+                bn_weight = ptweights[module_name + '.batchnorm.weight']
+                bn_running_var = ptweights[module_name + '.batchnorm.running_var']
+                bn_running_mean = ptweights[module_name + '.batchnorm.running_mean']
+
+                bn_weight_list = [
+                    bn_weight,  # scale gamma
+                    bn_bias,  # shift beta
+                    bn_running_mean,  # running mean
+                    bn_running_var  # running var
+                ]
+
+            expected_weights_shape = (size, size,tsize*input_channels, filters)
+            print('weight shape, expected : ', expected_weights_shape,
+                  'checkpoint: ', conv_weights_pt.shape,
+                  'created: ', conv_weights.shape)
+
+            if (conv_weights.shape != expected_weights_shape):
+                print('weight matrix shape is wrong, making a fake one')
+                fake_weights = True
+                conv_weights = np.random.rand(size, size, tsize*input_channels, filters)
+                conv_bias = np.zeros(filters)
+
+            conv_weights = [conv_weights] if batch_normalize else [
+                conv_weights, conv_bias
+            ]
+
+            inputs = []
+            outputs = []
+
+            for f in range(inputs_needed):
+#                print('input index: ', len(all_layers) - inputs_needed + f, ' shape: ', all_layers[len(all_layers) - inputs_needed + f].shape)
+                inputs.append(all_layers[len(all_layers) - inputs_needed + f])
+                if merge_in > 0:
+#                    print('merge input index: ', len(all_layers) - inputs_needed + f, ' shape: ', all_layers[len(all_layers) - (2*inputs_needed) + f].shape)
+                    inputs.append(all_layers[len(all_layers) - (2*inputs_needed) + f])
+
+            # Create Conv3d from Conv2D layers
+            if stride>1:
+                for f in range(len(inputs)):
+                    inputs[f] = ZeroPadding2D(((1, 0), (1, 0)))(inputs[f])
+
+            for f in range(int(frames/tstride)):
+                layers=[]
+                if tsize>1:
+#                    print('concatenate layers:')
+                    for t in range(tsize):
+                        # offset is constant with f, except if tstride,
+                        # then steps by extra step every time through
+                        if merge_in==0:
+                            layers.append(inputs[t + (f*(tstride))])
+                        else:
+                            layers.append(inputs[2*(t + (f * (tstride)))])
+                            layers.append(inputs[2*(t + (f * (tstride)))+1])
+                    cat_layer = Concatenate()(layers)
+                else:
+                    if merge_in==0:
+                        cat_layer = inputs[f*(tstride)]
+                    else:
+                        layers.append(inputs[2*f*(tstride)])
+                        layers.append(inputs[2*f*(tstride)+1])
+                        cat_layer = Concatenate()(layers)
+#                print(K.int_shape(cat_layer))
+                outputs.append((Conv2D(
+                                            filters, (size, size),
+                                            strides=(stride, stride),
+                                            kernel_regularizer=l2(weight_decay),
+                                            use_bias=not batch_normalize,
+                                            weights=conv_weights,
+                                            activation=None,
+                                            padding=padding))(cat_layer))
+
+            if batch_normalize:
+                for f in range(int(frames/tstride)):
+#                    print (all_layers[0-int(frames/tstride)])
+#                    print(bn_weight_list)
+                    outputs[f] = BatchNormalization(weights=bn_weight_list)(outputs[f])
+
+            if activation == 'relu6':
+                for f in range(int(frames / tstride)):
+                    outputs[f] = ReLU(max_value=6)(outputs[f])
+            elif activation == 'leaky':
+                for f in range(int(frames / tstride)):
+                    if not args.use_prelu:
+                        outputs[f] = LeakyReLU(alpha=0.1)(outputs[f])
+                    else:
+                        outputs[f] = PReLU(alpha_initializer=RandomNormal(mean=0.1, stddev=0.0, seed=None),
+                                   shared_axes=[1, 2])(outputs[f])
+
+            for f in range(int(frames / tstride)):
+                all_layers.append(outputs[f])
+
+            frames = int(frames/tstride)
+            if frames==0:
+                raise ValueError('tried to time stride single frame')
+
+            layer_names[layer_name] = len(all_layers) - 1
+
+        elif section.startswith('InvResidual'):
+
+            module_name = 'module_name' in cfg_parser[section]
+            if module_name:
+                module_name = cfg_parser[section]['module_name']
+                print(module_name)
+            else:
+                print('missing required module name for conv module')
+            layer_name = 'layer_name' in cfg_parser[section]
+            if layer_name:
+                layer_name = cfg_parser[section]['layer_name']
+                print(layer_name)
+            else:
+                layer_name = str(len(all_layers) - 1)
+            out_channels = int(cfg_parser[section]['out_channels'])
+            xratio = int(cfg_parser[section]['xratio'])
+            size = int(cfg_parser[section]['size'])
+            shift = 'shift' in cfg_parser[section]
+            stride = int(cfg_parser[section]['stride'])
+            tstride = int(cfg_parser[section]['tstride'])
+            print('frames: ', frames)
+
+            frames, fake_weights = invResidual(module_name, layer_name, frames,
+                                               out_channels, xratio, size, stride, shift, tstride,
+                                               fake_weights)
+
+
+        elif section.startswith('Linear'):
+            module_name = 'module_name' in cfg_parser[section]
+            if module_name:
+                module_name = cfg_parser[section]['module_name']
+                print(module_name)
+            else:
+                print('missing required module name for Linear module')
+            layer_name = 'layer_name' in cfg_parser[section]
+            if layer_name:
+                layer_name = cfg_parser[section]['layer_name']
+                print(layer_name)
+            else:
+                layer_name = str(len(all_layers) - 1)
+            share = 'share' in cfg_parser[section]
+            merge_in = 'merge_in' in cfg_parser[section]
+            if merge_in:
+                merge_in = int(cfg_parser[section]['merge_in'])
+            else:
+                merge_in = 0
+            no_output = 'no_output' in cfg_parser[section]
+            outputs = int(cfg_parser[section]['outputs'])
+            prev_layer_shape = K.int_shape(all_layers[-1])
+            print('prev_layer_shape: ', prev_layer_shape)
+            # if share, create output port with all its inputs
+            if share is True:
+                out_index.append(len(all_layers) - frames)
+                out_names.append(module_name + '_share')
+            # create input ports for merged-in data
+            if merge_in >0:
+                input_channels = input_channels + merge_in
+                in_names.append(module_name + '_merge_in')
+                all_layers.append(Input(shape=[merge_in], name=module_name + '_merge_in'))
+                print('merge_in input at: ', len(all_layers) - 1, ' shape: ', all_layers[-1].shape, ' plus: ', all_layers[-2].shape)
+                in_index.append(len(all_layers) - 1)
+                layers = []
+                layers.append(all_layers[-1])
+                layers.append(all_layers[-2])
+                all_layers.append(Concatenate()(layers))
+
+            size = np.prod(all_layers[-1].shape[1])     # skip the junk first dimension
+            if module_name + '.weight' in ptweights:
+                weights = np.transpose(ptweights[module_name + '.weight'], (1,0))
+                bias = ptweights[module_name + '.bias']
+            else:
+                print('weights missing')
+                print('Using fake weights for Linear layer')
+                weights = np.random.rand(size, outputs)
+                bias = np.random.rand(outputs)
+                fake_weights = True
+            print('total input size: ', size, 'output size: ', outputs, 'weights: ', weights.shape)
+            if (weights.shape[0], weights.shape[1]) != (size, outputs):
+                fake_weights = True
+                print('Using fake weights for Linear layer')
+                weights = np.random.rand(size, outputs)
+            if bias.shape != (outputs,):
+                fake_weights = True
+                print('Using fake bias for Linear layer')
+                bias = np.random.rand(outputs)
+            weights = [weights, bias]
+            print(all_layers[-1])
+            all_layers.append(Dense(outputs, weights=weights)(all_layers[-1]))
+            layer_names[layer_name] = len(all_layers) - 1
+
+        elif section.startswith('NBLinear'):
+            module_name = 'module_name' in cfg_parser[section]
+            if module_name:
+                module_name = cfg_parser[section]['module_name']
+                print(module_name)
+            else:
+                print('missing required module name for Linear module')
+            layer_name = 'layer_name' in cfg_parser[section]
+            if layer_name:
+                layer_name = cfg_parser[section]['layer_name']
+                print(layer_name)
+            else:
+                layer_name = str(len(all_layers) - 1)
+            share = 'share' in cfg_parser[section]
+            merge_in = 'merge_in' in cfg_parser[section]
+            if merge_in:
+                merge_in = int(cfg_parser[section]['merge_in'])
+            else:
+                merge_in = 0
+            no_output = 'no_output' in cfg_parser[section]
+            outputs = int(cfg_parser[section]['outputs'])
+            prev_layer_shape = K.int_shape(all_layers[-1])
+            print('prev_layer_shape: ', prev_layer_shape)
+            # if share, create output port with all its inputs
+            if share is True:
+                out_index.append(len(all_layers) - frames)
+                out_names.append(module_name + '_share')
+            # create input ports for merged-in data
+            if merge_in >0:
+                input_channels = input_channels + merge_in
+                in_names.append(module_name + '_merge_in')
+                all_layers.append(Input(shape=[merge_in], name=module_name + '_merge_in'))
+                print('merge_in input at: ', len(all_layers) - 1, ' shape: ', all_layers[-1].shape, ' plus: ', all_layers[-2].shape)
+                in_index.append(len(all_layers) - 1)
+                layers = []
+                layers.append(all_layers[-1])
+                layers.append(all_layers[-2])
+                all_layers.append(Concatenate()(layers))
+
+            size = np.prod(all_layers[-1].shape[1])     # skip the junk first dimension
+            if module_name + '.weight' in ptweights:
+                weights = np.transpose(ptweights[module_name + '.weight'], (1,0))
+            else:
+                print('weights missing')
+                print('Using fake weights for Linear layer')
+                weights = np.random.rand(size, outputs)
+                fake_weights = True
+            print('total input size: ', size, 'output size: ', outputs, 'weights: ', weights.shape)
+            if (weights.shape[0], weights.shape[1]) != (size, outputs):
+                fake_weights = True
+                print('Using fake weights for Linear layer')
+                weights = np.random.rand(size, outputs)
+            bias = np.zeros(outputs)
+            weights = [weights, bias]
+            print(all_layers[-1])
+            all_layers.append(Dense(outputs, weights=weights)(all_layers[-1]))
+            layer_names[layer_name] = len(all_layers) - 1
+
+        # section 'lookup' just to test finding names
+        elif section.startswith('lookup'):
+            ids = []
+            if 'names' in cfg_parser[section]:
+                ids = [layer_names[s.strip()]for s in cfg_parser[section]['names'].split(',')]
+            if 'layers' in cfg_parser[section]:
+                for i in cfg_parser[section]['layers'].split(','):
+                    if int(i) < 0:
+                        i = len(all_layers) + int(i)
+                    ids.append(int(i))
+            print ('lookup: ', ids)
+
+        elif section.startswith('route'):
+            if 'layer_name' in cfg_parser[section]:
+                layer_name =  cfg_parser[section]['layer_name']
+            else:
+                layer_name = str(len(all_layers) - 1)
+            ids = []
+            if 'names' in cfg_parser[section]:
+                ids = [layer_names[s.strip()]for s in cfg_parser[section]['names'].split(',')]
+                print('route from: ', ids )
+            if 'layers' in cfg_parser[section]:
+                for i in cfg_parser[section]['layers'].split(','):
+                    ids.append(int(i))
+            layers = [all_layers[i] for i in ids]
+            for l in layers:
+                print(K.int_shape(l))
+            if len(layers) > 1:
+                print('Concatenating route layers:', layers)
+                concatenate_layer = Concatenate()(layers)
+                all_layers.append(concatenate_layer)
+            else:
+                print(layers[0])
+                skip_layer = layers[0]  # only one layer to route
+                all_layers.append(skip_layer)
+            layer_names[layer_name] = len(all_layers) - 1
+            prev_layer_shape = K.int_shape(all_layers[-1])
+            image_size = prev_layer_shape[-2]
+            print('route image size: ', image_size)
+
+        elif section.startswith('maxpool'):
+            if 'layer_name' in cfg_parser[section]:
+                layer_name =  cfg_parser[section]['layer_name']
+            else:
+                layer_name = str(len(all_layers) - 1)
+            size = int(cfg_parser[section]['size'])
+            stride = int(cfg_parser[section]['stride'])
+            for f in range (frames):
+                all_layers.append(
+                    MaxPooling2D(
+                        pool_size=(size, size),
+                        strides=(stride, stride),
+                        padding='same')(all_layers[0-frames]))
+            layer_names[layer_name] = len(all_layers) - 1
+            prev_layer_shape = K.int_shape(all_layers[-1])
+            image_size = prev_layer_shape[-2]
+            print('maxpool image size: ', image_size)
+
+        elif section.startswith('shortcut'):
+            if 'layer_name' in cfg_parser[section]:
+                layer_name =  cfg_parser[section]['layer_name']
+            else:
+                layer_name = str(len(all_layers) - 1)
+            if 'name' in cfg_parser[section]:
+                index = layer_names[cfg_parser[section]['name'].strip()] - len(all_layers) - 1
+            if 'from' in cfg_parser[section]:
+                index = frames * int(cfg_parser[section]['from'])
+                if (index<0):
+                    print ('shortcut index: ', index)
+                else:
+                    print('warning: positive absolute layer reference number, I assume you know what you want')
+            activation = cfg_parser[section]['activation']
+            assert activation == 'linear', 'Only linear activation supported.'
+            for f in range (frames):
+                all_layers.append(Add()([all_layers[index], all_layers[0-frames]]))
+            layer_names[layer_name] = len(all_layers) - 1
+            prev_layer_shape = K.int_shape(all_layers[-1])
+            image_size = prev_layer_shape[-2]
+            print('shortcut image size: ', image_size)
+
+        elif section.startswith('upsample'):
+            if 'layer_name' in cfg_parser[section]:
+                layer_name =  cfg_parser[section]['layer_name']
+            else:
+                layer_name = str(len(all_layers) - 1)
+            stride = int(cfg_parser[section]['stride'])
+            assert stride == 2, 'Only stride=2 supported.'
+            for f in range (frames):
+                all_layers.append(UpSampling2D(stride)(all_layers[0-frames]))
+            layer_names[layer_name] = len(all_layers) - 1
+            prev_layer_shape = K.int_shape(all_layers[-1])
+            image_size = prev_layer_shape[-2]
+            print('upsample image size: ', image_size)
+
+        elif section.startswith('globalaveragepool'):
+            if 'layer_name' in cfg_parser[section]:
+                layer_name =  cfg_parser[section]['layer_name']
+            else:
+                layer_name = str(len(all_layers) - 1)
+            for f in range (frames):
+                all_layers.append(GlobalAveragePooling2D()(all_layers[0-frames]))
+            layer_names[layer_name] = len(all_layers) - 1
+            prev_layer_shape = K.int_shape(all_layers[-1])
+            image_size = prev_layer_shape[-2]
+            print('global average pooling: ', image_size)
+
+        elif section.startswith('Softmax'):
+            if 'layer_name' in cfg_parser[section]:
+                layer_name =  cfg_parser[section]['layer_name']
+            else:
+                layer_name = str(len(all_layers) - 1)
+            for f in range (frames):
+                all_layers.append(Softmax()(all_layers[0-frames]))
+            layer_names[layer_name] = len(all_layers) - 1
+            prev_layer_shape = K.int_shape(all_layers[-1])
+            image_size = prev_layer_shape[-2]
+            print('softmax: ', image_size)
+
+
+        elif section.startswith('yolo'):
+            if 'layer_name' in cfg_parser[section]:
+                layer_name =  cfg_parser[section]['layer_name']
+            else:
+                layer_name = str(len(all_layers) - 1)
+            out_index.append(len(all_layers)-1)
+            out_names.append('yolo_out_' + layer_name)
+            all_layers.append(None)
+            layer_names[layer_name] = len(all_layers) - 1
+
+        elif section.startswith('output'):
+            if 'layer_name' in cfg_parser[section]:
+                layer_name =  cfg_parser[section]['layer_name']
+                out_index.append(len(all_layers) - 1)
+                out_names.append('output_' + layer_name)
+#                all_layers.append(None)
+                layer_names[layer_name] = len(all_layers) - 1
+            else:
+                layer_name = coreml_list[-1][1][0]+'_output'
+                out_index.append(len(all_layers)-1)
+                out_names.append(layer_name)
+                all_layers.append(None)
+                layer_names[layer_name] = len(all_layers) - 1
+
+        elif section.startswith('Qoutput'):
+            if 'layer_name' in cfg_parser[section]:
+                layer_name = cfg_parser[section]['layer_name']
+                out_index.append(len(all_layers) - 4)
+                out_names.append('output4_' + layer_name)
+                out_index.append(len(all_layers) - 3)
+                out_names.append('output3_' + layer_name)
+                out_index.append(len(all_layers) - 2)
+                out_names.append('output2_' + layer_name)
+                out_index.append(len(all_layers) - 1)
+                out_names.append('output1_' + layer_name)
+                layer_names[layer_name] = len(all_layers) - 1
+            else:
+                layer_name = coreml_list[-1][1][0] + '_output'
+                out_index.append(len(all_layers) - 1)
+                out_names.append(layer_name)
+                all_layers.append(None)
+                layer_names[layer_name] = len(all_layers) - 1
+
+        elif section.startswith('input'):
+            frames = frames + 1
+            if 'size' in cfg_parser[section]:
+                size=[]
+#                size = [s.strip() for s in cfg_parser[section]['size'].split(',')]
+                for i in cfg_parser[section]['size'].split(','):
+                    if i == 'None':
+                        size.append(None)
+                    else:
+                        size.append(int(i))
+                print ('size: ',  size)
+            if 'layer_name' in cfg_parser[section]:
+                layer_name = cfg_parser[section]['layer_name']
+            else:
+                layer_name = str(len(all_layers) - 1)
+            input_layer = Input(shape=size, name=layer_name)
+            in_names.append(layer_name)
+            all_layers.append(input_layer)
+            if 'image' in cfg_parser[section]:
+                image_inputs.append(layer_name)
+            print('input layer: ', layer_name, ' shape: ', input_layer.shape)
+            in_index.append(len(all_layers) - 1)
+            coreml_list.append(('fake', (layer_name), {}, layer_name+':0'))
+
+        elif section.startswith('net'):
+            pass
+
+        else:
+            raise ValueError(
+                'Unsupported section header type: {}'.format(section))
+
+    # Create and save model.
+    print('done reading config file')
+    # assume the end of the network is an output if none are define.
+    if len(out_index)==0:
+        print('No outputs defined, so we are assuming last layer is the output and define it as such')
+        out_index.append(len(all_layers)-1)
+    model = Model(inputs=[all_layers[i] for i in in_index], outputs=[all_layers[i] for i in out_index])
+    print('done assembling model')
+    print(model.summary())
+
+    # print all inputs, formatted for use with coremltools Keras convertor
+    print ('input_names=[')
+    for name in in_names:
+        print("'" + name + "',")
+    print('],')
+
+    # print all outputs, formatted for use with coremltools Keras convertor
+    print ('output_names=[')
+    for name in out_names:
+        print("'" + name + "',")
+    print('],')
+
+    # Just for fun, print all inputs and outputs and their shapes.
+
+    # Inputs are actual Keras layers so we extract their names
+    # also build input_features for CoreML generation
+    for layer in [all_layers[i] for i in in_index]:
+        print('name: ', layer.name, '; shape: ', layer.shape)
+
+    # Outputs are not Keras layers, so we have a separate list of names for them
+    # - name comes from our list,
+    # - shape comes from the Keras layer they point to
+    out_layers = [all_layers[i] for i in out_index]
+    for i in range(len(out_names)):
+        print('name: ', out_names[i] + '; shape: ', out_layers[i].shape)
+
+    model.save('{}'.format(keras_file))
+    print('Saved Keras model to {}'.format(keras_file))
+
+    # Check to see if all weights have been read.
+#    remaining_weights = len(weights_file.read()) / 4
+
+#    print('Read {} of {} from Darknet weights.'.format(count, count +
+#                                                       remaining_weights))
+#    if remaining_weights > 0:
+#        print('Warning: {} unused weights'.format(remaining_weights))
+
+    if fake_weights == True:
+        print('************************* Warning!! **************************')
+        print('************************* Warning!! **************************')
+        print('************************* Warning!! **************************')
+        print('************************* Warning!! **************************')
+        print('Weights in checkpoint did not match weights required by network')
+        print('Fake weights were generated where they were needed!!!!!!!!!!!!')
+        print('************************* Warning!! **************************')
+        print('************************* Warning!! **************************')
+
+    # if args.plot_model:
+    #     plot(model, to_file=plot_file, show_shapes=True)
+    #     print('Saved model plot to {}'.format(plot_file))
+
+    if args.generate_coreml:
+
+        build_args = dict()
+
+        print('input_names', in_names)
+        print('output_names', out_names)
+        print('image_input_names', image_inputs)
+
+        build_args['input_names']=in_names
+        build_args['output_names']=out_names
+        build_args['image_input_names']=image_inputs
+
+        build_args['use_float_arraytype']=True
+
+        if args.float16:
+            build_args['model_precision']='float16'
+
+        if args.normalize_inputs:
+            if (args.red_bias):
+                build_args['red_bias'] = -(args.red_bias * 255.0)
+            if (args.green_bias):
+                build_args['green_bias'] = -(args.green_bias * 255.0)
+            if (args.blue_bias):
+                build_args['blue_bias'] = -(args.blue_bias * 255.0)
+            if (args.image_scale):
+                if args.image_scale != 1.0:
+                    print('setting image scale this way is not compatible with normalization')
+                    print('it is happening before bias, which is wrong')
+                    exit()
+        elif (args.image_scale):
+            build_args['image_scale'] = (1.0/args.image_scale)
+
+        coreml_model = coremltools.converters.keras.convert(keras_file, **build_args)
+        coreml_model.short_description = coreml_file
+        print ('\nsaving ', coreml_file)
+        coreml_model.save(coreml_file)
+
+        spec = coreml_model.get_spec()
+
+        if args.normalize_inputs:
+            print('\nimage input normalization requested!')
+            # get NN portion of the spec
+            nn_spec = spec.neuralNetwork
+            layers = nn_spec.layers  # this is a list of all the layers
+            layers_copy = copy.deepcopy(layers)  # make a copy of the layers, these will be added back later
+            del nn_spec.layers[:]  # delete all the layers
+
+            for ii in image_inputs:
+                # add a scale layer now
+                # since mlmodel is in protobuf format, we can add proto messages directly
+                # To look at more examples on how to add other layers: see "builder.py" file in coremltools repo
+
+                scale_layer = nn_spec.layers.add()
+                scale_layer.name = 'scale_' + ii
+                scale_layer.input.append(ii)
+                scale_layer.output.append(ii + '_scaled')
+                print('inserted scaling layer ', scale_layer.name,)
+                print(' input is image input ', ii, ', output is ', ii + '_scaled')
+
+                params = scale_layer.scale
+                params.scale.floatValue.extend([args.red_scale, args.green_scale, args.blue_scale])  # scale values for RGB
+                params.shapeScale.extend([3, 1, 1])  # shape of the scale vector
+
+            # now add back the rest of the layers (which happens to be just one in this case: the crop layer)
+            nn_spec.layers.extend(layers_copy)
+
+            for i in range(len(image_inputs)):
+                nn_spec.layers[i+len(image_inputs)].input[0] = image_inputs[i] + '_scaled'
+                print('attached layer ', nn_spec.layers[i+len(image_inputs)].name, ' to ', image_inputs[i] + '_scaled')
+
+#            print(spec.description)
+
+            coreml_model = coremltools.models.MLModel(spec)
+            coreml_model.short_description = normalized_file
+            print('\nsaving normalized network ', normalized_file)
+            coreml_model.save(normalized_file)
+
+
+    if fake_weights == True:
+        print('************************* Warning!! **************************')
+        print('************************* Warning!! **************************')
+        print('************************* Warning!! **************************')
+        print('************************* Warning!! **************************')
+        print('Weights in checkpoint did not match weights required by network')
+        print('Fake weights were generated where they were needed!!!!!!!!!!!!')
+        print('************************* Warning!! **************************')
+        print('************************* Warning!! **************************')
+
+if __name__ == '__main__':
+    _main(parser.parse_args())

--- a/scripts/conversion/convert_to_coreml.py
+++ b/scripts/conversion/convert_to_coreml.py
@@ -114,8 +114,7 @@ def merge_backbone_and_classifier_cfg_files(backbone_config_file, classifier_con
 
 def convert(backbone_settings, classifier_settings, output_name, float16, plot_model):
     output_dir = 'resources/coreml/'
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
 
     conversion_parameters = backbone_settings['conversion_parameters']
     keras_file = os.path.join(output_dir, output_name + '.h5')


### PR DESCRIPTION
This PR contains @marktodorovich's conversion script. Main difference with the original version is that I changed which parameters are exposed or hardcoded and I did some small refactoring changes early in the script, before the config file is parsed, so that it is possible to combine a generic backbone network with a specific classifier. After the config file is parsed, everything is pretty much the same.
 
Here is how to use it:
```
python scripts/conversion/convert_to_coreml.py --backbone=efficientnet --classifier=efficient_net_gesture_control --output_name=efficientnet_gesture_control --float16
```

For now, `--backbone=efficientnet` and `--classifier=efficient_net_gesture_control` are the only available options but it should be straightforward to later add support to more backbone networks (e.g. mobilenet) or other classifiers (e.g. fitness detector). I also think it won't be too hard to extend this to support custom classifiers once we have merged that finetuning script (#10)