### PR TITLE
Documentation/Refactor - display.py

### DIFF
--- a/realtimenet/display.py
+++ b/realtimenet/display.py
@@ -1,4 +1,5 @@
 import cv2
+import numpy as np
 from typing import Any
 from typing import List
 from typing import Tuple
@@ -7,7 +8,7 @@ from typing import Tuple
 FONT = cv2.FONT_HERSHEY_PLAIN
 
 
-def put_text(img: Any, text: str, position: Tuple[int, int]) -> Any:
+def put_text(img: np.ndarray, text: str, position: Tuple[int, int]) -> np.ndarray:
     """
     Draw a white text string on an image at a specified position and return the image.
 
@@ -39,7 +40,6 @@ class DisplayResults:
             Current supported options include:
                 - DisplayMETandCalories
                 - DisplayDetailedMETandCalories
-                - DisplayDetailedMETandCalories
                 - DisplayTopKClassificationOutputs
         :param border_size:
             Thickness of the display border.
@@ -50,7 +50,7 @@ class DisplayResults:
         self.display_ops = display_ops
         self.border_size = border_size
 
-    def show(self, img: Any, display_data: dict) -> Any:
+    def show(self, img: np.ndarray, display_data: dict) -> np.ndarray:
         """
         Show an image frame with data displayed on top.
 
@@ -88,12 +88,35 @@ class DisplayResults:
         cv2.destroyAllWindows()
 
 
-class DisplayMETandCalories:
-
-    lateral_offset = 350
-
+class BaseDisplay:
+    """
+    Base display for all displays. Subclasses should overwrite the `display` method.
+    """
     def __init__(self, y_offset=20):
         self.y_offset = y_offset
+
+    def display(self, img: np.ndarray, display_data: dict) -> np.ndarray:
+        """
+        Method to be implemented by subclasses.
+        This method writes display data onto an image frame.
+
+        :param img:
+            Image on which the display data should be written to.
+        :param display_data:
+            Data that should be displayed on an image frame.
+
+        :return:
+            The image with the display data written.
+        """
+        raise NotImplementedError
+
+
+class DisplayMETandCalories(BaseDisplay):
+    """
+    Display Metabolic Equivalent of Task (MET) and Calories information on an image frame.
+    """
+
+    lateral_offset = 350
 
     def display(self, img, display_data):
         offset = 10
@@ -103,10 +126,10 @@ class DisplayMETandCalories:
         return img
 
 
-class DisplayDetailedMETandCalories:
-
-    def __init__(self, y_offset=20):
-        self.y_offset = y_offset
+class DisplayDetailedMETandCalories(BaseDisplay):
+    """
+    Display detailed Metabolic Equivalent of Task (MET) and Calories information on an image frame.
+    """
 
     def display(self, img, display_data):
         offset = 10
@@ -121,14 +144,23 @@ class DisplayDetailedMETandCalories:
         return img
 
 
-class DisplayTopKClassificationOutputs:
+class DisplayTopKClassificationOutputs(BaseDisplay):
+    """
+    Display Top K Classification output on an image frame.
+    """
 
     lateral_offset = DisplayMETandCalories.lateral_offset
 
-    def __init__(self, top_k=1, threshold=0.2, y_offset=20):
+    def __init__(self, top_k=1, threshold=0.2, **kwargs):
+        """
+        :param top_k:
+            Number of the top classification labels to be displayed.
+        :param threshold:
+            Threshhold for the output to be displayed.
+        """
+        super().__init__(**kwargs)
         self.top_k = top_k
         self.threshold = threshold
-        self.y_offset = y_offset
 
     def display(self, img, display_data):
         sorted_predictions = display_data['sorted_predictions']

--- a/realtimenet/display.py
+++ b/realtimenet/display.py
@@ -1,25 +1,67 @@
 import cv2
+from typing import Any
+from typing import List
+from typing import Tuple
 
 
 FONT = cv2.FONT_HERSHEY_PLAIN
 
 
-def put_text(img, text, position):
+def put_text(img: Any, text: str, position: Tuple[int, int]) -> Any:
+    """
+    Draw a white text string on an image at a specified position and return the image.
+
+    :param img:
+        The image on which the text is to be drawn.
+    :param text:
+        The text to be written.
+    :param position:
+        A tuple of x and y coordinates of the bottom-left corner of the text in the image.
+
+    :return:
+        The image with the text string drawn.
+    """
     cv2.putText(img, text, position, FONT, 1, (255, 255, 255), 1, cv2.LINE_AA)
     return img
 
 
 class DisplayResults:
-
-    def __init__(self, title, display_ops, border_size=50):
-        self._window_title = '20bn-realtimenet'
+    """
+    Display window for an image frame with prediction outputs from a neural network.
+    """
+    def __init__(self, title: str, display_ops: List[Any], border_size: int = 50):
+        """
+        :param title:
+            Title of the image frame on display.
+        :param display_ops:
+            Additional options to be displayed on top of the image frame.
+            Display options are class objects that implement the `display(self, img, display_data)` method.
+            Current supported options include:
+                - DisplayMETandCalories
+                - DisplayDetailedMETandCalories
+                - DisplayDetailedMETandCalories
+                - DisplayTopKClassificationOutputs
+        :param border_size:
+            Thickness of the display border.
+        """
+        self._window_title = 'realtimenet'
         cv2.namedWindow(self._window_title, cv2.WINDOW_GUI_NORMAL + cv2.WINDOW_AUTOSIZE)
         self.title = title
         self.display_ops = display_ops
         self.border_size = border_size
 
-    def show(self, img, display_data):
+    def show(self, img: Any, display_data: dict) -> Any:
+        """
+        Show an image frame with data displayed on top.
 
+        :param img:
+            The image to be shown in the window.
+        :param display_data:
+            A dict of data that should be displayed in the image.
+
+        :return:
+            The image with displayed data.
+        """
         # Mirror the img
         img = img[:, ::-1].copy()
 
@@ -37,12 +79,12 @@ class DisplayResults:
             middle = int((img.shape[1] - textsize[0]) / 2)
             put_text(img, self.title, (middle, 20))
 
-        # Show
+        # Show the image in a window
         cv2.imshow(self._window_title, img)
         return img
 
-
     def clean_up(self):
+        """Close all windows that are created."""
         cv2.destroyAllWindows()
 
 

--- a/realtimenet/display.py
+++ b/realtimenet/display.py
@@ -1,6 +1,5 @@
 import cv2
 import numpy as np
-from typing import Any
 from typing import List
 from typing import Tuple
 

--- a/realtimenet/display.py
+++ b/realtimenet/display.py
@@ -26,68 +26,6 @@ def put_text(img: np.ndarray, text: str, position: Tuple[int, int]) -> np.ndarra
     return img
 
 
-class DisplayResults:
-    """
-    Display window for an image frame with prediction outputs from a neural network.
-    """
-    def __init__(self, title: str, display_ops: List[Any], border_size: int = 50):
-        """
-        :param title:
-            Title of the image frame on display.
-        :param display_ops:
-            Additional options to be displayed on top of the image frame.
-            Display options are class objects that implement the `display(self, img, display_data)` method.
-            Current supported options include:
-                - DisplayMETandCalories
-                - DisplayDetailedMETandCalories
-                - DisplayTopKClassificationOutputs
-        :param border_size:
-            Thickness of the display border.
-        """
-        self._window_title = 'realtimenet'
-        cv2.namedWindow(self._window_title, cv2.WINDOW_GUI_NORMAL + cv2.WINDOW_AUTOSIZE)
-        self.title = title
-        self.display_ops = display_ops
-        self.border_size = border_size
-
-    def show(self, img: np.ndarray, display_data: dict) -> np.ndarray:
-        """
-        Show an image frame with data displayed on top.
-
-        :param img:
-            The image to be shown in the window.
-        :param display_data:
-            A dict of data that should be displayed in the image.
-
-        :return:
-            The image with displayed data.
-        """
-        # Mirror the img
-        img = img[:, ::-1].copy()
-
-        # Add black borders
-        img = cv2.copyMakeBorder(img, self.border_size, 0, 0, 0, cv2.BORDER_CONSTANT)
-
-        # Display information on top
-        for display_op in self.display_ops:
-            img = display_op.display(img, display_data)
-
-        # Add title on top
-        if self.title:
-            img = cv2.copyMakeBorder(img, 50, 0, 0, 0, cv2.BORDER_CONSTANT)
-            textsize = cv2.getTextSize(self.title, FONT, 1, 2)[0]
-            middle = int((img.shape[1] - textsize[0]) / 2)
-            put_text(img, self.title, (middle, 20))
-
-        # Show the image in a window
-        cv2.imshow(self._window_title, img)
-        return img
-
-    def clean_up(self):
-        """Close all windows that are created."""
-        cv2.destroyAllWindows()
-
-
 class BaseDisplay:
     """
     Base display for all displays. Subclasses should overwrite the `display` method.
@@ -172,3 +110,65 @@ class DisplayTopKClassificationOutputs(BaseDisplay):
                 put_text(img, 'Proba: {:0.2f}'.format(proba), (10 + self.lateral_offset,
                                                                y_pos))
         return img
+
+
+class DisplayResults:
+    """
+    Display window for an image frame with prediction outputs from a neural network.
+    """
+    def __init__(self, title: str, display_ops: List[BaseDisplay], border_size: int = 50):
+        """
+        :param title:
+            Title of the image frame on display.
+        :param display_ops:
+            Additional options to be displayed on top of the image frame.
+            Display options are class objects that implement the `display(self, img, display_data)` method.
+            Current supported options include:
+                - DisplayMETandCalories
+                - DisplayDetailedMETandCalories
+                - DisplayTopKClassificationOutputs
+        :param border_size:
+            Thickness of the display border.
+        """
+        self._window_title = 'realtimenet'
+        cv2.namedWindow(self._window_title, cv2.WINDOW_GUI_NORMAL + cv2.WINDOW_AUTOSIZE)
+        self.title = title
+        self.display_ops = display_ops
+        self.border_size = border_size
+
+    def show(self, img: np.ndarray, display_data: dict) -> np.ndarray:
+        """
+        Show an image frame with data displayed on top.
+
+        :param img:
+            The image to be shown in the window.
+        :param display_data:
+            A dict of data that should be displayed in the image.
+
+        :return:
+            The image with displayed data.
+        """
+        # Mirror the img
+        img = img[:, ::-1].copy()
+
+        # Add black borders
+        img = cv2.copyMakeBorder(img, self.border_size, 0, 0, 0, cv2.BORDER_CONSTANT)
+
+        # Display information on top
+        for display_op in self.display_ops:
+            img = display_op.display(img, display_data)
+
+        # Add title on top
+        if self.title:
+            img = cv2.copyMakeBorder(img, 50, 0, 0, 0, cv2.BORDER_CONSTANT)
+            textsize = cv2.getTextSize(self.title, FONT, 1, 2)[0]
+            middle = int((img.shape[1] - textsize[0]) / 2)
+            put_text(img, self.title, (middle, 20))
+
+        # Show the image in a window
+        cv2.imshow(self._window_title, img)
+        return img
+
+    def clean_up(self):
+        """Close all windows that are created."""
+        cv2.destroyAllWindows()


### PR DESCRIPTION
This PR adds documentation to the entire `display.py` file. It also refactors and abstracts a `BaseDisplay` class for subclasses to inherit, which makes type hinting easier.