### PR TITLE
Fix: coreml conversion script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ docopt                  ==0.6.2       # MIT
 tensorflow              ==1.14.0
 keras                   ==2.2.4
 coremltools             ==3.3
+h5py                    ==2.10.0


### PR DESCRIPTION
This PR will change the `requirement.txt` in which the `h5py==2.10.0` is added. It will resolve the error of coreml conversion because KerasAPI does not support h5py>3.0.0.