### PR TITLE
Abstract Neural Network Class to replace nn.Module as type hint

### DIFF
--- a/realtimenet/controller.py
+++ b/realtimenet/controller.py
@@ -7,7 +7,7 @@ from realtimenet.camera import VideoSource
 from realtimenet.camera import VideoStream
 from realtimenet.display import DisplayResults
 from realtimenet.engine import InferenceEngine
-from realtimenet.downstream_tasks.nn_utils import RealtimeNN
+from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNetwork
 from realtimenet.downstream_tasks.postprocess import PostProcessor
 
 import cv2
@@ -17,7 +17,7 @@ import numpy as np
 class Controller:
     def __init__(
             self,
-            neural_network: RealtimeNN,
+            neural_network: RealtimeNeuralNetwork,
             post_processors: Union[PostProcessor, List[PostProcessor]],
             results_display: DisplayResults,
             callbacks: Optional[List[Callable]] = None,

--- a/realtimenet/controller.py
+++ b/realtimenet/controller.py
@@ -7,17 +7,17 @@ from realtimenet.camera import VideoSource
 from realtimenet.camera import VideoStream
 from realtimenet.display import DisplayResults
 from realtimenet.engine import InferenceEngine
+from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNet
 from realtimenet.downstream_tasks.postprocess import PostProcessor
 
 import cv2
 import numpy as np
-import torch.nn as nn
 
 
 class Controller:
     def __init__(
             self,
-            neural_network: nn.Module,
+            neural_network: RealtimeNeuralNet,
             post_processors: Union[PostProcessor, List[PostProcessor]],
             results_display: DisplayResults,
             callbacks: Optional[List[Callable]] = None,

--- a/realtimenet/controller.py
+++ b/realtimenet/controller.py
@@ -28,7 +28,6 @@ class Controller:
         """
         :param neural_network:
             The neural network that produces the predictions for the camera image.
-            TODO: Be more specific here
         :param post_processors:
             Post processors that are applied to the generated predictions to filter or manipulate the data.
             Refer to the PostProcessor class for more information.

--- a/realtimenet/controller.py
+++ b/realtimenet/controller.py
@@ -7,7 +7,7 @@ from realtimenet.camera import VideoSource
 from realtimenet.camera import VideoStream
 from realtimenet.display import DisplayResults
 from realtimenet.engine import InferenceEngine
-from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNet
+from realtimenet.downstream_tasks.nn_utils import RealtimeNN
 from realtimenet.downstream_tasks.postprocess import PostProcessor
 
 import cv2
@@ -17,7 +17,7 @@ import numpy as np
 class Controller:
     def __init__(
             self,
-            neural_network: RealtimeNeuralNet,
+            neural_network: RealtimeNN,
             post_processors: Union[PostProcessor, List[PostProcessor]],
             results_display: DisplayResults,
             callbacks: Optional[List[Callable]] = None,

--- a/realtimenet/controller.py
+++ b/realtimenet/controller.py
@@ -7,7 +7,7 @@ from realtimenet.camera import VideoSource
 from realtimenet.camera import VideoStream
 from realtimenet.display import DisplayResults
 from realtimenet.engine import InferenceEngine
-from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNetwork
+from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNet
 from realtimenet.downstream_tasks.postprocess import PostProcessor
 
 import cv2
@@ -17,7 +17,7 @@ import numpy as np
 class Controller:
     def __init__(
             self,
-            neural_network: RealtimeNeuralNetwork,
+            neural_network: RealtimeNeuralNet,
             post_processors: Union[PostProcessor, List[PostProcessor]],
             results_display: DisplayResults,
             callbacks: Optional[List[Callable]] = None,

--- a/realtimenet/downstream_tasks/nn_utils.py
+++ b/realtimenet/downstream_tasks/nn_utils.py
@@ -4,11 +4,11 @@ import torch.nn as nn
 from typing import Tuple
 
 
-class RealtimeNeuralNetwork(nn.Module):
+class RealtimeNeuralNet(nn.Module):
     """
     RealtimeNeuralNet is the abstract class for all neural networks used in InferenceEngine.
 
-    Subclasses should overwrite the methods in RealtimeNeuralNetwork.
+    Subclasses should overwrite the methods in RealtimeNeuralNet.
     """
     def __init__(self):
         super().__init__()
@@ -41,7 +41,7 @@ class RealtimeNeuralNetwork(nn.Module):
         raise NotImplementedError
 
 
-class Pipe(RealtimeNeuralNetwork):
+class Pipe(RealtimeNeuralNet):
 
     def __init__(self, feature_extractor, feature_converter):
         super().__init__()

--- a/realtimenet/downstream_tasks/nn_utils.py
+++ b/realtimenet/downstream_tasks/nn_utils.py
@@ -4,12 +4,11 @@ import torch.nn as nn
 from typing import Tuple
 
 
-class RealtimeNeuralNet(nn.Module):
+class RealtimeNN(nn.Module):
     """
-    RealtimeNeuralNet is the abstract class for all neural networks which
-    are to be fed into an instance of the InferenceEngine.
+    RealtimeNeuralNet is the abstract class for all neural networks used in InferenceEngine.
 
-    Subclasses should overwrite the methods in RealtimeNeuralNet.
+    Subclasses should overwrite the methods in RealtimeNN.
     """
     def __init__(self):
         super().__init__()
@@ -42,7 +41,7 @@ class RealtimeNeuralNet(nn.Module):
         raise NotImplementedError
 
 
-class Pipe(RealtimeNeuralNet):
+class Pipe(RealtimeNN):
 
     def __init__(self, feature_extractor, feature_converter):
         super().__init__()

--- a/realtimenet/downstream_tasks/nn_utils.py
+++ b/realtimenet/downstream_tasks/nn_utils.py
@@ -8,12 +8,6 @@ class RealtimeNeuralNet(nn.Module):
     def __init__(self):
         super().__init__()
 
-    def forward(self, input_tensor):
-        """
-        Feed forward of the input tensor to the feature extractor and converters.
-        """
-        raise NotImplementedError
-
     def preprocess(self, clip: np.ndarray):
         """
         Pre-process a clip from a video source.
@@ -64,7 +58,7 @@ class Pipe(RealtimeNeuralNet):
         return self.feature_extractor.fps
 
     @property
-    def step_size(self):
+    def step_size(self) -> int:
         return self.feature_extractor.step_size
 
     def preprocess(self, clip: np.ndarray):

--- a/realtimenet/downstream_tasks/nn_utils.py
+++ b/realtimenet/downstream_tasks/nn_utils.py
@@ -1,7 +1,48 @@
+import numpy as np
 import torch.nn as nn
 
+from typing import Tuple
 
-class Pipe(nn.Module):
+
+class RealtimeNeuralNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input_tensor):
+        """
+        Feed forward of the input tensor to the feature extractor and converters.
+        """
+        raise NotImplementedError
+
+    def preprocess(self, clip: np.ndarray):
+        """
+        Pre-process a clip from a video source.
+        """
+        raise NotImplementedError
+
+    @property
+    def step_size(self) -> int:
+        """
+        Return the step size of the neural network.
+        """
+        raise NotImplementedError
+
+    @property
+    def fps(self) -> int:
+        """
+        Return the frame per second rate of the neural network.
+        """
+        raise NotImplementedError
+
+    @property
+    def expected_frame_size(self) -> Tuple[int, int]:
+        """
+        Return the expected frame size of the neural network.
+        """
+        raise NotImplementedError
+
+
+class Pipe(RealtimeNeuralNet):
 
     def __init__(self, feature_extractor, feature_converter):
         super().__init__()
@@ -15,19 +56,19 @@ class Pipe(nn.Module):
         return self.feature_converter(feature)
 
     @property
-    def expected_frame_size(self):
+    def expected_frame_size(self) -> Tuple[int, int]:
         return self.feature_extractor.expected_frame_size
 
     @property
-    def fps(self):
+    def fps(self) -> int:
         return self.feature_extractor.fps
 
     @property
     def step_size(self):
         return self.feature_extractor.step_size
 
-    def preprocess(self, video):
-        return self.feature_extractor.preprocess(video)
+    def preprocess(self, clip: np.ndarray):
+        return self.feature_extractor.preprocess(clip)
 
 
 class LogisticRegression(nn.Sequential):

--- a/realtimenet/downstream_tasks/nn_utils.py
+++ b/realtimenet/downstream_tasks/nn_utils.py
@@ -5,6 +5,12 @@ from typing import Tuple
 
 
 class RealtimeNeuralNet(nn.Module):
+    """
+    RealtimeNeuralNet is the abstract class for all neural networks which
+    are to be fed into an instance of the InferenceEngine.
+
+    Subclasses should overwrite the methods in RealtimeNeuralNet.
+    """
     def __init__(self):
         super().__init__()
 

--- a/realtimenet/downstream_tasks/nn_utils.py
+++ b/realtimenet/downstream_tasks/nn_utils.py
@@ -4,11 +4,11 @@ import torch.nn as nn
 from typing import Tuple
 
 
-class RealtimeNN(nn.Module):
+class RealtimeNeuralNetwork(nn.Module):
     """
     RealtimeNeuralNet is the abstract class for all neural networks used in InferenceEngine.
 
-    Subclasses should overwrite the methods in RealtimeNN.
+    Subclasses should overwrite the methods in RealtimeNeuralNetwork.
     """
     def __init__(self):
         super().__init__()
@@ -41,7 +41,7 @@ class RealtimeNN(nn.Module):
         raise NotImplementedError
 
 
-class Pipe(RealtimeNN):
+class Pipe(RealtimeNeuralNetwork):
 
     def __init__(self, feature_extractor, feature_converter):
         super().__init__()

--- a/realtimenet/engine.py
+++ b/realtimenet/engine.py
@@ -10,10 +10,6 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-from realtimenet.camera import VideoStream
-from realtimenet.display import DisplayResults
-from realtimenet.downstream_tasks.postprocess import PostProcessor
-
 
 class InferenceEngine(Thread):
     """

--- a/realtimenet/engine.py
+++ b/realtimenet/engine.py
@@ -2,7 +2,7 @@ import numpy as np
 import queue
 import torch
 
-from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNetwork
+from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNet
 
 from threading import Thread
 from typing import List
@@ -16,7 +16,7 @@ class InferenceEngine(Thread):
     InferenceEngine takes in a neural network and uses it to output predictions
     either using the local machine's CPU or GPU.
     """
-    def __init__(self, net: RealtimeNeuralNetwork, use_gpu: bool = False):
+    def __init__(self, net: RealtimeNeuralNet, use_gpu: bool = False):
         """
         :param net:
             The neural network to be run by the inference engine.

--- a/realtimenet/engine.py
+++ b/realtimenet/engine.py
@@ -2,7 +2,7 @@ import numpy as np
 import queue
 import torch
 
-from realtimenet.downstream_tasks.nn_utils import RealtimeNN
+from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNetwork
 
 from threading import Thread
 from typing import List
@@ -16,7 +16,7 @@ class InferenceEngine(Thread):
     InferenceEngine takes in a neural network and uses it to output predictions
     either using the local machine's CPU or GPU.
     """
-    def __init__(self, net: RealtimeNN, use_gpu: bool = False):
+    def __init__(self, net: RealtimeNeuralNetwork, use_gpu: bool = False):
         """
         :param net:
             The neural network to be run by the inference engine.

--- a/realtimenet/engine.py
+++ b/realtimenet/engine.py
@@ -38,7 +38,7 @@ class InferenceEngine(Thread):
         return self.net.expected_frame_size
 
     @property
-    def fps(self) -> float:
+    def fps(self) -> int:
         """Frame rate of the inference engine's neural network."""
         return self.net.fps
 

--- a/realtimenet/engine.py
+++ b/realtimenet/engine.py
@@ -2,7 +2,7 @@ import numpy as np
 import queue
 import torch
 
-from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNet
+from realtimenet.downstream_tasks.nn_utils import RealtimeNN
 
 from threading import Thread
 from typing import List
@@ -16,7 +16,7 @@ class InferenceEngine(Thread):
     InferenceEngine takes in a neural network and uses it to output predictions
     either using the local machine's CPU or GPU.
     """
-    def __init__(self, net: RealtimeNeuralNet, use_gpu: bool = False):
+    def __init__(self, net: RealtimeNN, use_gpu: bool = False):
         """
         :param net:
             The neural network to be run by the inference engine.

--- a/realtimenet/engine.py
+++ b/realtimenet/engine.py
@@ -1,8 +1,8 @@
-import cv2 as cv2
 import numpy as np
 import queue
 import torch
-import torch.nn as nn
+
+from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNet
 
 from threading import Thread
 from typing import List
@@ -16,7 +16,7 @@ class InferenceEngine(Thread):
     InferenceEngine takes in a neural network and uses it to output predictions
     either using the local machine's CPU or GPU.
     """
-    def __init__(self, net: nn.Module, use_gpu: bool = False):
+    def __init__(self, net: RealtimeNeuralNet, use_gpu: bool = False):
         """
         :param net:
             The neural network to be run by the inference engine.

--- a/realtimenet/feature_extractors/mobilenet.py
+++ b/realtimenet/feature_extractors/mobilenet.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 
 from torch.nn.modules.utils import _triple
-from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNetwork
+from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNet
 
 
 class SteppableConv3dAs2d(nn.Conv2d):
@@ -147,7 +147,7 @@ class InvertedResidual(nn.Module):  # noqa: D101
             return input_[-n_out:]
 
 
-class StridedInflatedMobileNetV2(RealtimeNeuralNetwork):
+class StridedInflatedMobileNetV2(RealtimeNeuralNet):
 
     expected_frame_size = (256, 256)
     fps = 16

--- a/realtimenet/feature_extractors/mobilenet.py
+++ b/realtimenet/feature_extractors/mobilenet.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 
 from torch.nn.modules.utils import _triple
+from realtimenet.downstream_tasks.nn_utils import RealtimeNN
 
 
 class SteppableConv3dAs2d(nn.Conv2d):
@@ -146,7 +147,7 @@ class InvertedResidual(nn.Module):  # noqa: D101
             return input_[-n_out:]
 
 
-class StridedInflatedMobileNetV2(nn.Module):
+class StridedInflatedMobileNetV2(RealtimeNN):
 
     expected_frame_size = (256, 256)
     fps = 16

--- a/realtimenet/feature_extractors/mobilenet.py
+++ b/realtimenet/feature_extractors/mobilenet.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 
 from torch.nn.modules.utils import _triple
-from realtimenet.downstream_tasks.nn_utils import RealtimeNN
+from realtimenet.downstream_tasks.nn_utils import RealtimeNeuralNetwork
 
 
 class SteppableConv3dAs2d(nn.Conv2d):
@@ -147,7 +147,7 @@ class InvertedResidual(nn.Module):  # noqa: D101
             return input_[-n_out:]
 
 
-class StridedInflatedMobileNetV2(RealtimeNN):
+class StridedInflatedMobileNetV2(RealtimeNeuralNetwork):
 
     expected_frame_size = (256, 256)
     fps = 16


### PR DESCRIPTION
Per Guillaume's comment:
The parameter inside `Controller` class: `neural_network: nn.Module` might have a misleading type hint because not every `nn.Module` will work as a parameter for `InferenceEngine` expects those with certain attributes/methods (`net.fps`, `net.step_size`, `net.preprocess` etc...). We should create an abstract `RealtimeNeuralNet` class that clarifies the requirements.